### PR TITLE
Add What Broke Today RSS feed to Tech section

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,6 +985,7 @@ TechCrunch | http://feeds.feedburner.com/TechCrunch | techcrunch.com
 The Keyword | https://www.blog.google/rss/ | blog.google 
 The Next Web | https://thenextweb.com/feed/ | thenextweb.com 
 The Verge | https://www.youtube.com/feeds/videos.xml?user=TheVerge | youtube.com 
+What Broke Today | https://whatbroke.today/feed.xml | whatbroke.today
 The Verge -  All Posts | https://www.theverge.com/rss/index.xml | theverge.com 
 The Vergecast | https://feeds.megaphone.fm/vergecast | theverge.com 
 This Week in Tech (Audio) | https://feeds.twit.tv/twit.xml | twit.tv 


### PR DESCRIPTION
## Summary

Adding [What Broke Today](https://whatbroke.today/) RSS feed to the Tech section.

**What Broke Today** provides an RSS feed of cloud service outages:
- Monitors 100+ cloud services (AWS, Azure, GCP, GitHub, Cloudflare, etc.)
- Uses AI to filter and summarize service outages
- Great for developers and DevOps teams who want to stay informed

**Website**: https://whatbroke.today
**RSS Feed**: https://whatbroke.today/feed.xml