### PR TITLE
Add World Cup 2026 Tour football feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ Football - The People's Sport | https://www.reddit.com/r/football/.rss?format=xm
 Football News, Live Scores, Results &amp; Transfers - Goal.com | https://www.goal.com/feeds/en/news | goal.com 
 Football365 | https://www.football365.com/feed | football365.com 
 Soccer News | https://www.soccernews.com/feed | soccernews.com 
+World Cup 2026 Tour | https://ay-worldcup2026.zeabur.app/feed.xml | ay-worldcup2026.zeabur.app
 ### Funny
 Title | RSS Feed Url | Domain 
 -------|------------------|---------- 

--- a/recommended/with_category/Football.opml
+++ b/recommended/with_category/Football.opml
@@ -11,8 +11,9 @@
 			<outline text="EFL Championship" title="EFL Championship" description="Home of the EFL Championship on Reddit" xmlUrl="https://www.reddit.com/r/Championship/.rss?format=xml" type="rss" />
 			<outline text="Football - The People's Sport" title="Football - The People's Sport" description="Home of Football. News, Rumours, Analysis, gossip and much more." xmlUrl="https://www.reddit.com/r/football/.rss?format=xml" type="rss" />
 			<outline text="Football News, Live Scores, Results &amp; Transfers | Goal.com" title="Football News, Live Scores, Results &amp; Transfers | Goal.com" description="The latest football news, rumours, transfers and match reports from around the world." xmlUrl="https://www.goal.com/feeds/en/news" type="rss" />
-			<outline text="Football365" title="Football365" description="Views, Live Matches, Gossip & more | Football365.com" xmlUrl="https://www.football365.com/feed" type="rss" />
+			<outline text="Football365" title="Football365" description="Views, Live Matches, Gossip &amp; more | Football365.com" xmlUrl="https://www.football365.com/feed" type="rss" />
 			<outline text="Soccer News" title="Soccer News" description="The Latest Soccer News from around the globe." xmlUrl="https://www.soccernews.com/feed" type="rss" />
+			<outline text="World Cup 2026 Tour" title="World Cup 2026 Tour" description="World Cup 2026 match schedule, live match hubs, calendar feed, widgets, and share tools." xmlUrl="https://ay-worldcup2026.zeabur.app/feed.xml" type="rss" />
 		</outline>
 	</body>
 </opml>

--- a/recommended/without_category/Football.opml
+++ b/recommended/without_category/Football.opml
@@ -10,7 +10,8 @@
 		<outline text="EFL Championship" title="EFL Championship" description="Home of the EFL Championship on Reddit" xmlUrl="https://www.reddit.com/r/Championship/.rss?format=xml" type="rss" />
 		<outline text="Football - The People's Sport" title="Football - The People's Sport" description="Home of Football. News, Rumours, Analysis, gossip and much more." xmlUrl="https://www.reddit.com/r/football/.rss?format=xml" type="rss" />
 		<outline text="Football News, Live Scores, Results &amp; Transfers | Goal.com" title="Football News, Live Scores, Results &amp; Transfers | Goal.com" description="The latest football news, rumours, transfers and match reports from around the world." xmlUrl="https://www.goal.com/feeds/en/news" type="rss" />
-		<outline text="Football365" title="Football365" description="Views, Live Matches, Gossip & more | Football365.com" xmlUrl="https://www.football365.com/feed" type="rss" />
+		<outline text="Football365" title="Football365" description="Views, Live Matches, Gossip &amp; more | Football365.com" xmlUrl="https://www.football365.com/feed" type="rss" />
 		<outline text="Soccer News" title="Soccer News" description="The Latest Soccer News from around the globe." xmlUrl="https://www.soccernews.com/feed" type="rss" />
+		<outline text="World Cup 2026 Tour" title="World Cup 2026 Tour" description="World Cup 2026 match schedule, live match hubs, calendar feed, widgets, and share tools." xmlUrl="https://ay-worldcup2026.zeabur.app/feed.xml" type="rss" />
 	</body>
 </opml>


### PR DESCRIPTION
Adds the World Cup 2026 Tour RSS feed to the Football recommended feeds.\n\nWhy it fits:\n- Football/World Cup-specific feed\n- Includes match schedule, live match hubs, calendar feed, widgets, and share tools\n- Useful while the 2026 World Cup is active\n\nVerified:\n- https://ay-worldcup2026.zeabur.app/feed.xml returns HTTP 200 with content type application/rss+xml\n- The feed includes WebSub hub/self links\n- Current feed has 176 RSS items\n- Both edited Football OPML files parse successfully with Python ElementTree\n\nI also escaped an existing unescaped ampersand in the Football365 description so the edited OPML files are valid XML.